### PR TITLE
Fixes #745

### DIFF
--- a/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RootResource.java
+++ b/extensions/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/RootResource.java
@@ -10,5 +10,4 @@ public class RootResource {
     public String root() {
         return "Root Resource";
     }
-
 }

--- a/integration-tests/main/src/main/java/io/quarkus/example/rest/TestResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/example/rest/TestResource.java
@@ -38,6 +38,12 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.reactivex.Single;
 
@@ -156,6 +162,36 @@ public class TestResource {
         entity.setName("my entity name");
         entity.setValue("my entity value");
         return Response.ok(entity).build();
+    }
+
+    @GET
+    @Path("/openapi")
+    @Produces("application/json")
+    @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class)))
+    public MyOpenApiEntityV1 openApiResponse() {
+        MyOpenApiEntityV1 entity = new MyOpenApiEntityV1();
+        entity.setName("my openapi entity name");
+        return entity;
+    }
+
+    @GET
+    @Path("/openapi/{version}")
+    @Produces("application/json")
+    @APIResponses({
+            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV1.class))),
+            @APIResponse(content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = MyOpenApiEntityV2.class)))
+    })
+    public MyOpenApiEntityV1 openApiResponses(@PathParam("version") String version) {
+        if ("v1".equals(version)) {
+            MyOpenApiEntityV1 entityV1 = new MyOpenApiEntityV1();
+            entityV1.setName("my openapi entity version one name");
+            return entityV1;
+        }
+
+        MyOpenApiEntityV2 entityV2 = new MyOpenApiEntityV2();
+        entityV2.setName("my openapi entity version two name");
+        entityV2.setValue(version);
+        return entityV2;
     }
 
     @GET
@@ -286,6 +322,32 @@ public class TestResource {
         public void setName(String name) {
             this.name = name;
         }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @Schema()
+    public static class MyOpenApiEntityV1 {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Schema()
+    public static class MyOpenApiEntityV2 extends MyOpenApiEntityV1 {
+        private String value;
 
         public String getValue() {
             return value;

--- a/integration-tests/main/src/test/java/io/quarkus/example/test/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/example/test/JaxRSTestCase.java
@@ -122,4 +122,23 @@ public class JaxRSTestCase {
                 .body("name", is("my entity name"),
                         "value", is("my entity value"));
     }
+
+    @Test
+    public void testOpenApiSchemaResponse() {
+        RestAssured.when().get("/test/openapi").then()
+                .body("name", is("my openapi entity name"));
+    }
+
+    @Test
+    public void testOpenApiSchemaResponsesV1() {
+        RestAssured.when().get("/test/openapi/v1").then()
+                .body("name", is("my openapi entity version one name"));
+    }
+
+    @Test
+    public void testOpenApiSchemaResponsesV2() {
+        RestAssured.when().get("/test/openapi/v2").then()
+                .body("name", is("my openapi entity version two name"),
+                        "value", is("v2"));
+    }
 }


### PR DESCRIPTION
A proposal to scan all MP OpenAPI schema declaration see [issue](https://github.com/quarkusio/quarkus/issues/745) 

- The main idea is to scan for SCHEMA annotation and mark them as `ReflectiveHierarchy `
- Scan APIResponse annotation for schema declaration and mark the results (` implementation , not, oneOf, anyOf, allOf` values) for reflection. 
- Scan APIResponses annotation and do as above. 